### PR TITLE
use different strftime lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ npm test
 
 ## Dependencies
 
-- [domready](https://github.com/ded/domready): modern domready
-- [prettydate](https://github.com/bluesmoon/node-prettydate): Format dates nicely
-- [relative-date](https://github.com/n-johnson/relative-date): Javascript module for outputting relative dates.
+- [domready](https://ghub.io/domready): modern domready
+- [strftime](https://ghub.io/prettydate): Format dates nicely
+- [relative-date](https://ghub.io/relative-date): Javascript module for outputting relative dates.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var domready = require('domready')
-var strftime = require('prettydate').strftime
+var strftime = require('strftime')
 var relative = require('relative-date')
 
 module.exports = function () {
@@ -27,7 +27,7 @@ var formatDates = function () {
     }
 
     var format = el.dataset.format || 'relative'
-    var result = format === 'relative' ? relative(date) : strftime(date, format)
+    var result = format === 'relative' ? relative(date) : strftime(format, date)
 
     el.textContent = result
   })

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "brfs": "^1.4.3",
     "dateutil": "^0.1.0",
     "domready": "^1.0.8",
-    "prettydate": "0.0.1",
-    "relative-date": "^1.1.3"
+    "relative-date": "^1.1.3",
+    "strftime": "^0.10.0"
   },
   "devDependencies": {
     "browserify": "^13.0.1",


### PR DESCRIPTION
https://github.com/bluesmoon/node-prettydate hasn't been touched since 2012. Something about it doesn't work in the latest Chrome.

This PR replaces prettydate with [strftime](https://github.com/samsonjs/strftime) which has more contributors and is downloaded like mad on npm.

cc @sarahs